### PR TITLE
JACDAC Glossary

### DIFF
--- a/bus_sim.py
+++ b/bus_sim.py
@@ -29,7 +29,8 @@ class JDDevice:
         self.count = 0
         self.address = random.randint(1, 255)
 
-        allocated = random.randint(0, 1)
+        # allocated = random.randint(0, 10)
+        allocated = 0
         if allocated == 0:
             existing_addresses = [d.address for d in existing if d.state == d.JD_DEVICE_STATE_ALLOCATED]
             self.address = self.__generate_unique_addr(existing_addresses)
@@ -93,7 +94,7 @@ if ask_for_input:
     devices_per_bus = int(input("Enter the number of devices per bus:"))
 else:
     bus_count = 2
-    devices_per_bus = 120
+    devices_per_bus = 60
 
 # create buses
 buses = []
@@ -116,9 +117,11 @@ if bus_count * devices_per_bus > 254:
     print("cannot merge buses, total device count is greater than the maximum supported device amount (254)")
     exit()
 
-print("merging buses")
-
+# list(set([d.address for d in buses[0].devices]) & set([d.address for d in buses[1].devices]))
 merged_bus = JDBus(buses)
+duplicate_count = len(merged_bus.devices) - len(set([device.address for device in merged_bus.devices]))
+
+print("%d duplicates detected, merging buses" % duplicate_count)
 handle_addresses([merged_bus])
 
-print ("Merging of buses took %d moves" % ( buses[i].moves))
+print ("Merging of buses took %d moves" % ( merged_bus.moves))

--- a/bus_sim.py
+++ b/bus_sim.py
@@ -7,6 +7,7 @@ class JDBus:
             for b in buses:
                 self.devices += b.devices
         self.moves = 0
+        self.ticks = 0
 
     def addDevice(self, device):
         self.devices += [device]
@@ -68,6 +69,7 @@ def handle_addresses(buses):
                     if device.count == 3:
                         device.state = device.JD_DEVICE_STATE_ALLOCATED
 
+            time_incremented = False
             for d1 in b.devices:
                 for d2 in b.devices:
                     if d1 == d2:
@@ -77,12 +79,17 @@ def handle_addresses(buses):
                         done = False
                         order = random.randint(0,1)
 
-                        if order and d1.state != d1.JD_DEVICE_STATE_ALLOCATED:
+                        if order:
+                        # if order and d1.state != d1.JD_DEVICE_STATE_ALLOCATED:
                             d1.reinit(bus_addresses)
                         else:
                             d2.reinit(bus_addresses)
 
                         b.moves += 1
+
+                if not time_incremented:
+                    b.ticks += 1
+                    time_incremented = True
 
                 if d1.state == d1.JD_DEVICE_STATE_PROPOSING:
                     done = False
@@ -94,7 +101,7 @@ if ask_for_input:
     devices_per_bus = int(input("Enter the number of devices per bus:"))
 else:
     bus_count = 2
-    devices_per_bus = 60
+    devices_per_bus = 120
 
 # create buses
 buses = []
@@ -124,4 +131,4 @@ duplicate_count = len(merged_bus.devices) - len(set([device.address for device i
 print("%d duplicates detected, merging buses" % duplicate_count)
 handle_addresses([merged_bus])
 
-print ("Merging of buses took %d moves" % ( merged_bus.moves))
+print ("Merging of buses took %d ms and %d moves" % ( merged_bus.ticks * 500, merged_bus.moves))

--- a/bus_sim.py
+++ b/bus_sim.py
@@ -53,7 +53,8 @@ def handle_addresses(buses):
     while not done:
         done = True
         for b in buses:
-            bus_addresses = [d.address for d in b.devices if d.state == d.JD_DEVICE_STATE_ALLOCATED]
+            bus_addresses = [d.address for d in b.devices]
+            # bus_addresses = [d.address for d in b.devices if d.state == d.JD_DEVICE_STATE_ALLOCATED]
             # bus_addresses = []
             for device in b.devices:
                 if device.state == device.JD_DEVICE_STATE_UNITIALISED:

--- a/bus_sim.py
+++ b/bus_sim.py
@@ -1,0 +1,123 @@
+import random
+
+class JDBus:
+    def __init__(self, buses = None):
+        self.devices = []
+        if buses is not None:
+            for b in buses:
+                self.devices += b.devices
+        self.moves = 0
+
+    def addDevice(self, device):
+        self.devices += [device]
+
+class JDDevice:
+    JD_DEVICE_STATE_UNITIALISED = 0
+    JD_DEVICE_STATE_PROPOSING = 1
+    JD_DEVICE_STATE_ALLOCATED = 2
+    def __generate_unique_addr(self, bus_addresses):
+        addr = random.randint(1, 255)
+        done = False
+        while not done:
+            if addr in bus_addresses:
+                addr = random.randint(1, 255)
+            else:
+                break
+        return addr
+
+    def __init__(self, existing):
+        self.count = 0
+        self.address = random.randint(1, 255)
+
+        allocated = random.randint(0, 1)
+        if allocated == 0:
+            existing_addresses = [d.address for d in existing if d.state == d.JD_DEVICE_STATE_ALLOCATED]
+            self.address = self.__generate_unique_addr(existing_addresses)
+            self.state = self.JD_DEVICE_STATE_ALLOCATED
+        else:
+            self.state = self.JD_DEVICE_STATE_UNITIALISED
+
+    def reinit(self, bus_addresses = None):
+        self.count = 0
+        # if given bus_addresses we can better pick a next best guess
+        if bus_addresses is None:
+            self.address = random.randint(1, 255)
+        else:
+            self.address = self.__generate_unique_addr(bus_addresses)
+
+        self.state = self.JD_DEVICE_STATE_PROPOSING
+
+def handle_addresses(buses):
+    done = False
+    print ("Allocating/resolving addresses")
+    while not done:
+        done = True
+        for b in buses:
+            bus_addresses = [d.address for d in b.devices if d.state == d.JD_DEVICE_STATE_ALLOCATED]
+            # bus_addresses = []
+            for device in b.devices:
+                if device.state == device.JD_DEVICE_STATE_UNITIALISED:
+                    device.count = 0
+                    device.state = device.JD_DEVICE_STATE_PROPOSING
+
+                elif device.state == device.JD_DEVICE_STATE_PROPOSING:
+                    device.count += 1
+
+                    if device.count == 3:
+                        device.state = device.JD_DEVICE_STATE_ALLOCATED
+
+            for d1 in b.devices:
+                for d2 in b.devices:
+                    if d1 == d2:
+                        continue
+
+                    if d1.address == d2.address:
+                        done = False
+                        order = random.randint(0,1)
+
+                        if order and d1.state != d1.JD_DEVICE_STATE_ALLOCATED:
+                            d1.reinit(bus_addresses)
+                        else:
+                            d2.reinit(bus_addresses)
+
+                        b.moves += 1
+
+                if d1.state == d1.JD_DEVICE_STATE_PROPOSING:
+                    done = False
+
+ask_for_input = False
+
+if ask_for_input:
+    bus_count = int(input("Enter the number of buses:"))
+    devices_per_bus = int(input("Enter the number of devices per bus:"))
+else:
+    bus_count = 2
+    devices_per_bus = 120
+
+# create buses
+buses = []
+for i in range(0,bus_count):
+    buses += [JDBus()]
+
+# allocate devices
+for b in buses:
+    for i in range(0,devices_per_bus):
+        b.addDevice(JDDevice(b.devices))
+
+
+# allocate addresses
+handle_addresses(buses)
+
+for i in range(0,bus_count):
+    print ("Bus %d allocation of addresses took %d moves" % (i + 1, buses[i].moves))
+
+if bus_count * devices_per_bus > 254:
+    print("cannot merge buses, total device count is greater than the maximum supported device amount (254)")
+    exit()
+
+print("merging buses")
+
+merged_bus = JDBus(buses)
+handle_addresses([merged_bus])
+
+print ("Merging of buses took %d moves" % ( buses[i].moves))

--- a/index.md
+++ b/index.md
@@ -4,6 +4,36 @@ JACDAC (Joint Asynchronous Communications; Device Agnostic Control) is a single 
 
 Please visit the [motivation](#Motivation) section to read about the motivating factors for JACDAC.
 
+# Glossary
+
+* JACDAC - Joint Asynchronous Communications; Device Agnostic Control (JACDAC) is a single wire protocol for the plug and play of sensors, actuators, and microcontrollers for use within the contexts of rapid prototyping, making, and computer science education.
+
+## Physical Layer Terminology
+* Physical Layer - The layer that handles transmission and reception of packets with other devices. Specifically, we refer to the line level state i.e. what a packet looks like.
+* Bus - JACDAC devices are connected to each other using a "single cable". This is simply a conceptual notion, as JACDAC devices can be connected with multiple cables.
+* Packet (commonly referred to as a JDPacket) - The structure of the data packet transmitted on the Bus.
+* Lo Pulse - The period for which the bus is driven lo (10, 20, 40, or 80 microseconds), indicating the upcoming baud rate of the packet.
+* Frame - A frame is formed of a Lo Pulse followed by a packet.
+
+## Device Terminology
+
+* Device - A JACDAC device is composed of 0 or more drivers.
+* Session identifier (previously address) - Identifies a device and its capabilities.
+* Unique identifier (previously serial number) - uniquely identifies a device, using EUI64 format. Any JACDAC device must have a unique identifier.
+
+## Service Terminology
+* Service (previously driver) - An interface to the JACDAC bus that provisions a resource for a user.
+* Service State (previous device) - Maintains the state of a service at runtime.
+* Service Class (previously driver class) - provides typing for a service i.e. an accelerometer
+* Host Service - Hosts a resource for others to use on the bus. This type of service is enumerated on the bus in control packets.
+* Client Service - Uses a resource provided by a host on the bus. This type of service is not enumerated on the bus.
+* Host Broadcast Service (previously broadcast driver) - Packets are received based on class in addition to receiving packets directly using address and offset.
+* Client Broadcast Service (Previously SnifferDriver) - Packets are received based on class and cannot be received directly as the service is not enumerated in control packets. This can be thought of as "wireshark" for a specific service class.
+* Control Service - Handles the routing of packets to the appropriate drivers and the mounting / unmounting of devices. The control service is not enumerated on the bus and is addressed using the special broadcast session identifier "0".
+* Control Packet - A control packet enumerates a device on the bus and contains the unique device identifier and the services it is presenting for others to use.
+* ServiceInformation - is the name for the services data provided in a control packet.
+* Service Offset - When combined with a  device address, it allows the identification of a specific Host Service.
+
 # The Physical Layer
 
 For reliable communications, embedded programmers tend to stay clear of UART: there is no common clock, the baud rate must be pre-determined, and there is no bus arbitration on the reception and transmission lines. Fortunately, hardware has improved over time adding DMA buffering and auto-baud detection thus improving reliability.

--- a/index.md
+++ b/index.md
@@ -18,8 +18,8 @@ Please visit the [motivation](#Motivation) section to read about the motivating 
 ## Device Terminology
 
 * Device - A JACDAC device is composed of 0 or more drivers.
-* Session identifier (previously address) - Identifies a device and its capabilities.
-* Unique identifier (previously serial number) - uniquely identifies a device, using EUI64 format. Any JACDAC device must have a unique identifier.
+* Device address - Identifies a device and its capabilities.
+* Unique device identifier (previously serial number) - uniquely identifies a device, using EUI64 format. Any JACDAC device must have a unique identifier.
 
 ## Service Terminology
 * Service (previously driver) - An interface to the JACDAC bus that provisions a resource for a user.

--- a/index.md
+++ b/index.md
@@ -1,6 +1,6 @@
 # What is JACDAC?
 
-JACDAC (Joint Asynchronous Communications; Device Agnostic Control) is a single wire protocol for the plug and play of sensors, actuators, and microcontrollers within the context of rapid prototyping, making, and computer science education. JACDAC operates in a bus topology and requires devices have a microcontroller with UART, Timer, and GPIO interrupt capabilities.
+JACDAC (Joint Asynchronous Communications; Device Agnostic Control) is a single wire protocol for the plug and play of sensors, actuators, and microcontrollers for use within the contexts of rapid prototyping, making, and computer science education. JACDAC operates in a bus topology and requires devices have a microcontroller with UART, Timer, and GPIO interrupt capabilities.
 
 Please visit the [motivation](#Motivation) section to read about the motivating factors for JACDAC.
 

--- a/index.md
+++ b/index.md
@@ -32,7 +32,7 @@ Please visit the [motivation](#Motivation) section to read about the motivating 
 * Control Service - Handles the routing of packets to the appropriate drivers and the mounting / unmounting of devices. The control service is not enumerated on the bus and is addressed using the special broadcast session identifier "0".
 * Control Packet - A control packet enumerates a device on the bus and contains the unique device identifier and the services it is presenting for others to use.
 * ServiceInformation - is the name for the services data provided in a control packet.
-* Service Offset - When combined with a  device address, it allows the identification of a specific Host Service.
+* Service Number - When combined with a  device address, it allows the identification of a specific Host Service on a device.
 
 # The Physical Layer
 

--- a/index.md
+++ b/index.md
@@ -17,7 +17,7 @@ Please visit the [motivation](#Motivation) section to read about the motivating 
 
 ## Device Terminology
 
-* Device - A JACDAC device is composed of 0 or more drivers.
+* Device - A JACDAC device is composed of 0 or more services.
 * Device address - Identifies a device and its capabilities.
 * Unique device identifier (previously serial number) - uniquely identifies a device, using EUI64 format. Any JACDAC device must have a unique identifier.
 
@@ -27,7 +27,7 @@ Please visit the [motivation](#Motivation) section to read about the motivating 
 * Service Class (previously driver class) - provides typing for a service i.e. an accelerometer
 * Host Service - Hosts a resource for others to use on the bus. This type of service is enumerated on the bus in control packets.
 * Client Service - Uses a resource provided by a host on the bus. This type of service is not enumerated on the bus.
-* Host Broadcast Service (previously broadcast driver) - Packets are received based on class in addition to receiving packets directly using address and offset.
+* Host Broadcast Service (previously broadcast driver) - Packets are received based on class in addition to receiving packets directly using address and service number.
 * Client Broadcast Service (Previously SnifferDriver) - Packets are received based on class and cannot be received directly as the service is not enumerated in control packets. This can be thought of as "wireshark" for a specific service class.
 * Control Service - Handles the routing of packets to the appropriate drivers and the mounting / unmounting of devices. The control service is not enumerated on the bus and is addressed using the special broadcast session identifier "0".
 * Control Packet - A control packet enumerates a device on the bus and contains the unique device identifier and the services it is presenting for others to use.


### PR DESCRIPTION
# Glossary

* JACDAC - Joint Asynchronous Communications; Device Agnostic Control (JACDAC) is a single wire protocol for the plug and play of sensors, actuators, and microcontrollers for use within the contexts of rapid prototyping, making, and computer science education.

## Physical Layer Terminology
* Physical Layer - The layer that handles transmission and reception of packets with other devices. Specifically, we refer to the line level state i.e. what a packet looks like.
* Bus - JACDAC devices are connected to each other using a "single cable". This is simply a conceptual notion, as JACDAC devices can be connected with multiple cables.
* Packet (commonly referred to as a JDPacket) - The structure of the data packet transmitted on the Bus.
* Lo Pulse - The period for which the bus is driven lo (10, 20, 40, or 80 microseconds), indicating the upcoming baud rate of the packet.
* Frame - A frame is formed of a Lo Pulse followed by a packet.

## Device Terminology

* Device - A JACDAC device is composed of 0 or more services.
* Device address - Identifies a device and its capabilities.
* Unique device identifier (previously serial number) - uniquely identifies a device, using EUI64 format. Any JACDAC device must have a unique identifier.

## Service Terminology
* Service (previously driver) - An interface to the JACDAC bus that provisions a resource for a user.
* Service State (previous device) - Maintains the state of a service at runtime.
* Service Class (previously driver class) - provides typing for a service i.e. an accelerometer
* Host Service - Hosts a resource for others to use on the bus. This type of service is enumerated on the bus in control packets.
* Client Service - Uses a resource provided by a host on the bus. This type of service is not enumerated on the bus.
* Host Broadcast Service (previously broadcast driver) - Packets are received based on class in addition to receiving packets directly using address and service number.
* Client Broadcast Service (Previously SnifferDriver) - Packets are received based on class and cannot be received directly as the service is not enumerated in control packets. This can be thought of as "wireshark" for a specific service class.
* Control Service - Handles the routing of packets to the appropriate drivers and the mounting / unmounting of devices. The control service is not enumerated on the bus and is addressed using the special broadcast session identifier "0".
* Control Packet - A control packet enumerates a device on the bus and contains the unique device identifier and the services it is presenting for others to use.
* ServiceInformation - is the name for the services data provided in a control packet.
* Service Number - When combined with a  device address, it allows the identification of a specific Host Service on a device.