### PR TITLE
Add new services (ADC, Audio, PWM) and modify services (I2C, Serial)

### DIFF
--- a/services/adc.md
+++ b/services/adc.md
@@ -1,0 +1,20 @@
+# ADC
+
+    identifier: 0x1d723135
+    tags: io
+    camel: ADC
+    extends: _sensor
+    status: experimental
+
+Read in the analogue value of a pin, if it has been set to AnalogIn through the GPIO service. The GPIO service provides the main configuration for access to the GPIO hardware.
+
+## Registers
+
+    packed ro state @ reading {
+    repeats:
+        pin: u8
+        value: u16.16 V
+    }
+
+For each pin that has been configured to `AnalogIn` in the GPIO service, the pin number and value is returned to the client. This is streamed at a low-ish speed, but it's also automatically reported whenever
+an input pin changes value (throttled to ~100Hz).

--- a/services/audio.md
+++ b/services/audio.md
@@ -1,0 +1,55 @@
+# Audio
+
+    identifier: 0x1f9cdb36
+    camel: audio
+    status: experimental
+    group: sound
+
+Receive an uncompressed byte stream of audio data to store in the buffer and play when requested.
+
+# Registers
+
+    rw sample_rate: u32 Hz @ 0x80
+
+The sample rate for the audio stream.
+
+    const max_sample_rate: u32 Hz @ 0x180
+
+The maximum sample rate supported.
+
+    rw bits_per_sample: u8 @ 0x81
+
+The number of bits per sample for the audio stream.
+
+    const max_bits_per_sample: u8 @ 0x181
+
+The maximum number of bits per sample supported.
+
+    rw volume: u0.8 @ 0x82
+
+The volume for the audio stream, between 0 and 1.
+
+    const buffer_size: u32 B @ 0x182
+
+The maximum size of the audio buffer in bytes.
+
+    ro playing: bool @ 0x183
+
+Whether the audio stream is currently playing.
+
+# Commands
+
+    packed command load_audio @ 0x80 {
+        start_playing: bool
+        buffer: pipe
+    }
+
+Load data into the buffer. If `start_playing` is set to true, the audio will play immediately.
+
+    command play @ 0x81 { }
+
+Start playing the audio from the buffer.
+
+    command stop @ 0x82 { }
+
+Stop playing the audio.

--- a/services/i2c.md
+++ b/services/i2c.md
@@ -21,14 +21,14 @@ Indicates whether the I2C is working.
         NAckData = 2
         NoI2C = 3
     }
-    unique command transaction @ 0x80 {
+    unique packed command transaction @ 0x80 {
         address: u8
         num_read: u8 B
-        write_buf: bytes
+        write_buf: pipe
     }
-    report {
+    packed report {
         status: Status
-        read_buf: bytes
+        read_buf: pipe
     }
 
 `address` is 7-bit.

--- a/services/pwm.md
+++ b/services/pwm.md
@@ -1,0 +1,96 @@
+# PWM
+
+    identifier: 0x1aada0c2
+    tags: io
+    camel: PWM
+
+Set the PWM output for a pin. The pins are indexed `0 ... num_pins-1`.The indexing does not correspond to hardware pin names, nor labels on the board (see `get_pin_info` command for that), and should **not** be exposed to the user.
+
+This service does not rely on the GPIO service, enabling a pin will set that pin in the GPIO service to `Alternate` mode.
+
+## Registers
+
+    ro num_pins: u8 # { absolute_max=128 } @ 0x180
+
+Return the number of pins supporting PWM.
+
+    ro frequencies @ 0x181 {
+    repeats: 
+        frequency: u32 Hz 
+    } 
+
+Return the supported frequencies for use by the pins.
+
+    ro concurrent_pwm: u8 # @ 0x182
+
+Return the number of pins that can have PWM enabled simultaneously, 0 for no limit. 
+
+## Commands
+
+    enum Mode: u8 {
+        PWMDisabled = 0
+        PWMEnabled = 1
+    }
+
+    command SetMode @ 0x80 {
+        pin: u8
+        mode: Mode
+    }
+
+Set the enabled state of PWM on a specific pin by its number. If the maximum number of concurrent PWM pins is exceeded, the command will fail.
+
+    packed command SetDutyCycle @ 0x81 {
+        pin: u8
+        duty_cycle: u0.16 /100
+    }
+
+Set the duty cycle for a specific pin.
+
+    packed command SetFrequency @ 0x82 {
+        pin: u8
+        frequency: u32 Hz
+    }
+
+Set the frequency for a specific pin. If the frequency is not supported, the closest supported frequency will be used instead.
+
+    command pin_info @ 0x83 {
+        pin: u8
+    } 
+    packed report {
+        pin: u8
+        hw_pin: u8
+        mode: Mode
+        duty_cycle: u0.16 /100
+        frequency: u32 Hz
+        label: string
+    }
+
+Get the info about a specific pin by its number.
+
+    command pin_by_label @ 0x84 {
+        label: string
+    } 
+    packed report {
+        pin: u8
+        hw_pin: u8
+        mode: Mode
+        duty_cycle: u0.16 /100
+        frequency: u32 Hz
+        label: string
+    }
+
+Get the info about a specific pin by its label.
+
+    command pin_by_hw_pin @ 0x85 {
+        hw_pin: u8
+    } 
+    packed report {
+        pin: u8
+        hw_pin: u8
+        mode: Mode
+        duty_cycle: u0.16 /100
+        frequency: u32 Hz
+        label: string
+    }
+
+Get the info about a specific pin by its hardware pin number.

--- a/services/serial.md
+++ b/services/serial.md
@@ -37,20 +37,24 @@ The number of stop bits at the end of a frame. Either 1 or 2.
 
 The parity mode.
 
-    rw buffer_size: u8 # @ 0x84
+    rw buffer_size: u32 # @ 0x84
     
 A positive, non-zero value indicating the size of the read and write buffers that should be created.
+
+    const max_buffer_size: u32 # @ 0x180
+
+The maximum buffer size supported by the service.
 
 ## Commands
 
     unique command send @ 0x80 {
-        data: bytes
+        data: pipe
     }
 
 Send a buffer of data over the serial transport.
 
     report received @ 0x80 {
-       data: bytes
+       data: pipe
     }
     
 Raised when a buffer of data is received.


### PR DESCRIPTION
New services: ADC, Audio, and PWM

I2C and Serial have been modified to use Pipe, to reduce the current packet-enforced byte limit on payloads. 

spectool has not been run in this PR, however it has been checked against it and no errors are found.